### PR TITLE
feature/All where operator when asking for known in uknown; `2019 in years` PAPI-2556

### DIFF
--- a/src/linq/operator/types.ts
+++ b/src/linq/operator/types.ts
@@ -30,7 +30,7 @@ type BigIntExpression = { type: 'bigint', operator: '==' | '!=' | '>' | '>=' | '
 type RecordExpression = { type: 'record', operator: '==' | '!=' | '>' | '>=' | '<' | '<=', property: string, value: Record<string, any> }
 type DateExpression = { type: 'date', operator: '==' | '!=' | '>' | '>=' | '<' | '<=', property: string, value: Date }
 type BooleanExpression = { type: 'boolean', operator: '==' | '!=' | '>' | '>=' | '<' | '<=', property: string, value: boolean }
-type ArrayExpression = { type: 'array', operator: '==' | '!=' | '>' | '>=' | '<' | '<=' | 'in', property: string, value: Array<any> }
+type ArrayExpression = { type: 'array', operator: '==' | '!=' | '>' | '>=' | '<' | '<=' | 'in' | 'all', property: string, value: Array<any> }
 type CollectionExpression = { type: 'expression', operator: 'any' | 'all', property: string, value: IterableIterator<WhereExpression> }
 
 export type WhereExpression = NullExpression | StringExpression | NumberExpression | BigIntExpression | RecordExpression | DateExpression | BooleanExpression | ArrayExpression | CollectionExpression

--- a/src/linq/peg/grammar/javascript.pegjs
+++ b/src/linq/peg/grammar/javascript.pegjs
@@ -292,7 +292,7 @@ QualifiedIdentifier
         index: expr
       };
     }
-    / !ReservedWord first:(Identifier / StringLiteral / TemplateLiteral) rest:(DOT QualifiedIdentifier)*
+    / !ReservedWord first:(Identifier / StringLiteral / TemplateLiteral) rest:(DOT QualifiedIdentifier)+
     {
        return buildTree(first, rest, function(result, element) {
         return {

--- a/src/linq/peg/parser/parser.ts
+++ b/src/linq/peg/parser/parser.ts
@@ -133,6 +133,14 @@ export function transform(expression: Record<string, any>): IExpression {
 
         case 'MemberExpression':
             switch(expression.property.type) {
+                case 'RelationalExpression':
+                    // didn't manage to get this to work in the pegjs grammar, so we do it here
+                    return new LogicalExpression(
+                        LogicalOperatorType.In, 
+                        transform(expression.property.left),
+                        new MemberExpression(transform(expression.object), transform(expression.property.right))
+                    )
+                
                 case 'CallExpression':
                     child = transform(expression.property);
                     (<MethodExpression>child).caller = transform(expression.object)

--- a/src/test/operator/where.ts
+++ b/src/test/operator/where.ts
@@ -7,6 +7,7 @@ type Car = {
     type: { 
         make: string
         model: string
+        years: number[]
     }
     year: number
     years: number[]
@@ -56,6 +57,26 @@ describe('When using operator', () => {
                 const intersection = Array.from(operator.intersection)
 
                 expect(intersection.length).to.equal(1)
+            })
+
+            it('an expression with nested object', () => {
+                const operator = whereOperator<Car>(car => car.type.make == 'toyota')
+
+                if(operator.type !== LinqType.Where)
+                    throw new Error('expecting where operator')
+
+                expect(operator.expression.toString()).to.equal(`(car) => car.type.make == "toyota"`)
+
+                const intersection = Array.from(operator.intersection)
+
+                expect(intersection.length).to.equal(1)
+
+                const expression = intersection[0]
+
+                expect(expression.operator).to.equal('==')
+                expect(expression.property).to.equal('type.make')
+                expect(expression.type).to.equal('string')
+                expect(expression.value).to.equal('toyota')
             })
 
             it('an expression using multiple ands', () => {
@@ -175,6 +196,27 @@ describe('When using operator', () => {
                 expect(secondInExpr.type).to.equal('array')
                 expect(secondInExpr.value).to.have.members([2020])
             })
+
+            it('an in expression for nested array property', () => {
+                const operator = whereOperator<Car>(car => car.type.years.includes(2019))
+
+                if(operator.type !== LinqType.Where)
+                    throw new Error('expecting where operator')
+
+                expect(operator.expression.toString()).to.equal(`(car) => 2019 in car.type.years`)
+
+                const intersection = Array.from(operator.intersection)
+
+                expect(intersection.length).to.equal(1)
+
+                const inExpr = intersection[0]
+
+                expect(inExpr.operator).to.equal('all')
+                expect(inExpr.property).to.equal('type.years')
+                expect(inExpr.type).to.equal('array')
+                expect(inExpr.value).to.have.members([2019])
+            })
+
         })
 
         describe('for odata', () => {

--- a/src/test/operator/where.ts
+++ b/src/test/operator/where.ts
@@ -9,11 +9,11 @@ type Car = {
         model: string
     }
     year: number
+    years: number[]
 }
 
 describe('When using operator', () => {
-    describe('where', () => {
-
+    describe('where and sets', () => {
         describe('for javascript', () => {
             it('should use sets for an expression', () => {
                 const operator = whereOperator<Car>(car => (car.year == 2015 && car.location == 'DK') || car.location == 'NO')
@@ -27,8 +27,27 @@ describe('When using operator', () => {
                 expect(sets.length).to.equal(2)
                 expect(expressions.length).to.equal(3)
             })
+        })
 
-            it('should use intersection for an expression', () => {
+        describe('for odata', () => {
+            it('should use sets for an expression', () => {
+                const operator = whereOperator<Car>(`(year eq 2015 and location eq 'DK') or location eq 'NO'`)
+
+                if(operator.type !== LinqType.Where)
+                    throw new Error('expecting where operator')
+
+                const sets = Array.from(operator.sets)
+                const expressions = sets.flatMap(sets => Array.from(sets))
+
+                expect(sets.length).to.equal(2)
+                expect(expressions.length).to.equal(3)
+            })
+        })
+    })
+
+    describe('where and intersection', () => {
+        describe('for javascript', () => {
+            it('an expression', () => {
                 const operator = whereOperator<Car>(car => car.location == 'NO' && (car.year == 2019 || car.year == 2020 || car.year == 2021))
 
                 if(operator.type !== LinqType.Where)
@@ -39,7 +58,7 @@ describe('When using operator', () => {
                 expect(intersection.length).to.equal(1)
             })
 
-            it('should use intersection for an expression using multiple ands', () => {
+            it('an expression using multiple ands', () => {
                 const operator = whereOperator<Car>(car => car.year == 2015 && car.location == 'NO' && car.id > 5)
 
                 if(operator.type !== LinqType.Where)
@@ -50,7 +69,7 @@ describe('When using operator', () => {
                 expect(intersection.length).to.equal(3)
             })
 
-            it('should use intersection correct for an in expression', () => {
+            it('an in expression', () => {
                 const operator = whereOperator<Car>(car => car.location == 'NO' && [2019, 2020, 2021].includes(car.year))
 
                 if(operator.type !== LinqType.Where)
@@ -70,7 +89,7 @@ describe('When using operator', () => {
                 expect(inExpr.value).to.have.members([2021, 2020, 2019])
             })
 
-            it('should use intersection correct for an in expression with single element', () => {
+            it('an in expression with single element', () => {
                 const operator = whereOperator<Car>(car => [2021].includes(car.year))
 
                 if(operator.type !== LinqType.Where)
@@ -90,7 +109,7 @@ describe('When using operator', () => {
                 expect(inExpr.value).to.have.members([2021])
             })
 
-            it('should use intersection correct for an in expression with nested object', () => {
+            it('an in expression with nested object', () => {
                 const operator = whereOperator<Car>(car => car.location == 'NO' && ['toyota', 'ford'].includes(car.type.make))
 
                 if(operator.type !== LinqType.Where)
@@ -109,23 +128,57 @@ describe('When using operator', () => {
                 expect(inExpr.type).to.equal('array')
                 expect(inExpr.value).to.have.members(['ford', 'toyota'])
             })
-        })
 
-        describe('for odata', () => {
-            it('should use sets for an expression', () => {
-                const operator = whereOperator<Car>(`(year eq 2015 and location eq 'DK') or location eq 'NO'`)
+            it('an in expression for array property', () => {
+                const operator = whereOperator<Car>(car => car.years.includes(2019))
 
                 if(operator.type !== LinqType.Where)
                     throw new Error('expecting where operator')
 
-                const sets = Array.from(operator.sets)
-                const expressions = sets.flatMap(sets => Array.from(sets))
+                expect(operator.expression.toString()).to.equal(`(car) => 2019 in car.years`)
 
-                expect(sets.length).to.equal(2)
-                expect(expressions.length).to.equal(3)
+                const intersection = Array.from(operator.intersection)
+
+                expect(intersection.length).to.equal(1)
+
+                const inExpr = intersection[0]
+
+                expect(inExpr.operator).to.equal('all')
+                expect(inExpr.property).to.equal('years')
+                expect(inExpr.type).to.equal('array')
+                expect(inExpr.value).to.have.members([2019])
             })
 
-            it('should use intersection for an expression', () => {
+            it('an in expression for array property with multiple values', () => {
+                const operator = whereOperator<Car>(car => car.years.includes(2019) && car.years.includes(2020))
+
+                if(operator.type !== LinqType.Where)
+                    throw new Error('expecting where operator')
+
+                expect(operator.expression.toString()).to.equal(`(car) => (2019 in car.years && 2020 in car.years)`)
+
+                const intersection = Array.from(operator.intersection)
+
+                expect(intersection.length).to.equal(2)
+
+                const firstInExpr = intersection[0]
+
+                expect(firstInExpr.operator).to.equal('all')
+                expect(firstInExpr.property).to.equal('years')
+                expect(firstInExpr.type).to.equal('array')
+                expect(firstInExpr.value).to.have.members([2019])
+
+                const secondInExpr = intersection[1]
+
+                expect(secondInExpr.operator).to.equal('all')
+                expect(secondInExpr.property).to.equal('years')
+                expect(secondInExpr.type).to.equal('array')
+                expect(secondInExpr.value).to.have.members([2020])
+            })
+        })
+
+        describe('for odata', () => {
+            it('an expression', () => {
                 const operator = whereOperator<Car>(`location eq 'NO' and (year eq 2019 or year eq 2020 or year eq 2021)`)
 
                 if(operator.type !== LinqType.Where)
@@ -136,7 +189,7 @@ describe('When using operator', () => {
                 expect(intersection.length).to.equal(1)
             })
 
-            it('should use intersection for an expression using multiple ands', () => {
+            it('an expression using multiple ands', () => {
                 const operator = whereOperator<Car>(`year eq 2015 and location eq 'NO' and id gt 5`)
 
                 if(operator.type !== LinqType.Where)
@@ -147,19 +200,19 @@ describe('When using operator', () => {
                 expect(intersection.length).to.equal(3)
             })
 
-            it('should use intersection correct for an in expression', () => {
-                const operator = whereOperator<Car>(`location eq 'NO' and year in (2019, 2020, 2021)`)
+            it('an in expression', () => {
+                const operator = whereOperator<Car>(`year in (2019, 2020, 2021)`)
 
                 if(operator.type !== LinqType.Where)
                     throw new Error('expecting where operator')
 
-                expect(operator.expression.toString()).to.equal(`(location == "NO" && year in [2019, 2020, 2021])`)
+                expect(operator.expression.toString()).to.equal(`year in [2019, 2020, 2021]`)
 
                 const intersection = Array.from(operator.intersection)
 
-                expect(intersection.length).to.equal(2)
+                expect(intersection.length).to.equal(1)
 
-                const inExpr = intersection[1]
+                const inExpr = intersection[0]
 
                 expect(inExpr.operator).to.equal('in')
                 expect(inExpr.property).to.equal('year')
@@ -167,7 +220,7 @@ describe('When using operator', () => {
                 expect(inExpr.value).to.have.members([2021, 2020, 2019])
             })
 
-            it('should use intersection correct for an in expression with single element', () => {
+            it('an in expression with single element', () => {
                 const operator = whereOperator<Car>(`year in (2021)`)
 
                 if(operator.type !== LinqType.Where)
@@ -187,7 +240,7 @@ describe('When using operator', () => {
                 expect(inExpr.value).to.have.members([2021])
             })
 
-            it('should use intersection correct for an in expression with nested object', () => {
+            it('an in expression with nested object', () => {
                 const operator = whereOperator<Car>(`location eq 'NO' and type/make in ('toyota', 'ford')`)
 
                 if(operator.type !== LinqType.Where)
@@ -206,6 +259,54 @@ describe('When using operator', () => {
                 expect(inExpr.type).to.equal('array')
                 expect(inExpr.value).to.have.members(['ford', 'toyota'])
             })
+
+            it('an in expression for array property', () => {
+                const operator = whereOperator<Car>(`2019 in years`)
+
+                if(operator.type !== LinqType.Where)
+                    throw new Error('expecting where operator')
+
+                expect(operator.expression.toString()).to.equal(`2019 in years`)
+
+                const intersection = Array.from(operator.intersection)
+
+                expect(intersection.length).to.equal(1)
+
+                const inExpr = intersection[0]
+
+                expect(inExpr.operator).to.equal('all')
+                expect(inExpr.property).to.equal('years')
+                expect(inExpr.type).to.equal('array')
+                expect(inExpr.value).to.have.members([2019])
+            })
+
+            it('an in expression for array property with multiple values', () => {
+                const operator = whereOperator<Car>(`2019 in years and 2020 in years`)
+
+                if(operator.type !== LinqType.Where)
+                    throw new Error('expecting where operator')
+
+                expect(operator.expression.toString()).to.equal(`(2019 in years && 2020 in years)`)
+
+                const intersection = Array.from(operator.intersection)
+
+                expect(intersection.length).to.equal(2)
+
+                const firstInExpr = intersection[0]
+
+                expect(firstInExpr.operator).to.equal('all')
+                expect(firstInExpr.property).to.equal('years')
+                expect(firstInExpr.type).to.equal('array')
+                expect(firstInExpr.value).to.have.members([2019])
+
+                const secondInExpr = intersection[1]
+
+                expect(secondInExpr.operator).to.equal('all')
+                expect(secondInExpr.property).to.equal('years')
+                expect(secondInExpr.type).to.equal('array')
+                expect(secondInExpr.value).to.have.members([2020])
+            })
+
         })
     })
 })


### PR DESCRIPTION
This pull request includes several changes to the `src/linq/operator` and `src/test/operator` modules to enhance support for the 'all' operator and improve test coverage. The most important changes include adding support for the 'all' operator in various functions, updating the `ArrayExpression` type, and expanding test cases to cover the new functionality.

Enhancements to operator support:

* [`src/linq/operator/types.ts`](diffhunk://#diff-82f0d237b103f53a79f619ee203cab36ca20294d6a5d156d48d2d5551bee5c64L33-R33): Added 'all' to the list of allowed operators in the `ArrayExpression` type.
* [`src/linq/operator/whereoperator.ts`](diffhunk://#diff-70df44e3544556a874c86d2a6546402a6822b560092041a6ee8f1b7797670d40L110-R114): Updated functions such as `visitExpression`, `visitLeaf`, `getOperator`, `getPropertyValue`, and `getPropertyName` to handle the 'all' operator. [[1]](diffhunk://#diff-70df44e3544556a874c86d2a6546402a6822b560092041a6ee8f1b7797670d40L110-R114) [[2]](diffhunk://#diff-70df44e3544556a874c86d2a6546402a6822b560092041a6ee8f1b7797670d40R305-R308) [[3]](diffhunk://#diff-70df44e3544556a874c86d2a6546402a6822b560092041a6ee8f1b7797670d40L417-R421) [[4]](diffhunk://#diff-70df44e3544556a874c86d2a6546402a6822b560092041a6ee8f1b7797670d40R443-R449) [[5]](diffhunk://#diff-70df44e3544556a874c86d2a6546402a6822b560092041a6ee8f1b7797670d40R459-R466) [[6]](diffhunk://#diff-70df44e3544556a874c86d2a6546402a6822b560092041a6ee8f1b7797670d40R509-R516)

Parser updates:

* [`src/linq/peg/grammar/javascript.pegjs`](diffhunk://#diff-450e7ea86d98ee3f59ab7f403a65a4be01ecf3255c4c5a627c7de384674a21a1L295-R295): Modified the `QualifiedIdentifier` rule to ensure proper parsing of expressions involving the 'all' operator.
* [`src/linq/peg/parser/parser.ts`](diffhunk://#diff-a38a871f59ef6e99bf3907fbd00b01e3969f2799439001eb03225ee90a3eb2a6R136-R143): Added logic to handle `RelationalExpression` in the `transform` function. [[1]](diffhunk://#diff-a38a871f59ef6e99bf3907fbd00b01e3969f2799439001eb03225ee90a3eb2a6R136-R143) [[2]](diffhunk://#diff-a38a871f59ef6e99bf3907fbd00b01e3969f2799439001eb03225ee90a3eb2a6L156-R190)

Expanded test coverage:

* [`src/test/operator/where.ts`](diffhunk://#diff-c25e44ab1213b1d19bef4cb516b1254cd13eec8928d0ef12f48f70a5ff522a3dR10-R17): Added multiple new test cases to cover scenarios involving the 'all' operator, including nested objects and array properties. [[1]](diffhunk://#diff-c25e44ab1213b1d19bef4cb516b1254cd13eec8928d0ef12f48f70a5ff522a3dR10-R17) [[2]](diffhunk://#diff-c25e44ab1213b1d19bef4cb516b1254cd13eec8928d0ef12f48f70a5ff522a3dR31-R51) [[3]](diffhunk://#diff-c25e44ab1213b1d19bef4cb516b1254cd13eec8928d0ef12f48f70a5ff522a3dL42-R82) [[4]](diffhunk://#diff-c25e44ab1213b1d19bef4cb516b1254cd13eec8928d0ef12f48f70a5ff522a3dL53-R93) [[5]](diffhunk://#diff-c25e44ab1213b1d19bef4cb516b1254cd13eec8928d0ef12f48f70a5ff522a3dL73-R113) [[6]](diffhunk://#diff-c25e44ab1213b1d19bef4cb516b1254cd13eec8928d0ef12f48f70a5ff522a3dL93-R133) [[7]](diffhunk://#diff-c25e44ab1213b1d19bef4cb516b1254cd13eec8928d0ef12f48f70a5ff522a3dR152-R223) [[8]](diffhunk://#diff-c25e44ab1213b1d19bef4cb516b1254cd13eec8928d0ef12f48f70a5ff522a3dL150-R265) [[9]](diffhunk://#diff-c25e44ab1213b1d19bef4cb516b1254cd13eec8928d0ef12f48f70a5ff522a3dL190-R285)